### PR TITLE
Give the opportunity to use our custom insert_data() function

### DIFF
--- a/h5pxapikachu.php
+++ b/h5pxapikachu.php
@@ -236,6 +236,14 @@ function insert_data() {
 	global $wpdb;
 
 	$xapi     = $_REQUEST['xapi'];
+
+	// If fuction h5pxapikatchu_custom_insert_data exists, delegate
+	if (function_exists('h5pxapikatchu_custom_insert_data')) {
+		if ( h5pxapikatchu_custom_insert_data( $xapi ) ) {
+			wp_die();
+		}
+	}
+
 	$xapidata = new XAPIDATA( $xapi );
 
 	$actor             = $xapidata->get_actor();

--- a/h5pxapikachu.php
+++ b/h5pxapikachu.php
@@ -236,15 +236,6 @@ function insert_data() {
 	global $wpdb;
 
 	$xapi     = $_REQUEST['xapi'];
-
-	// If fuction h5pxapikatchu_custom_insert_data exists, delegate
-	// Added in version 0.4.3
-	if (function_exists('h5pxapikatchu_custom_insert_data')) {
-		if ( h5pxapikatchu_custom_insert_data( $xapi ) ) {
-			wp_die();
-		}
-	}
-
 	$xapidata = new XAPIDATA( $xapi );
 
 	$actor             = $xapidata->get_actor();
@@ -268,6 +259,13 @@ function insert_data() {
 		$xapi = null;
 	}
 
+	// If fuction h5pxapikatchu_custom_insert_data exists, delegate
+	// Added in version 0.4.3
+	if (function_exists('h5pxapikatchu_custom_insert_data')) {
+		if ( h5pxapikatchu_custom_insert_data( $actor, $verb, $object, $result, $xapi ) ) {
+			wp_die();
+		}
+	}
 	$ok = Database::insert_data( $actor, $verb, $object, $result, $xapi );
 
 	// We could handle database errors here using $ok.

--- a/h5pxapikachu.php
+++ b/h5pxapikachu.php
@@ -6,7 +6,7 @@
  * Text Domain: H5PXAPIKATCHU
  * Domain Path: /languages
  * Description: Catch and store xAPI statements sent by H5P
- * Version: 0.4.2
+ * Version: 0.4.3
  * Author: Oliver Tacke
  * Author URI: https://www.olivertacke.de
  * License: MIT
@@ -18,7 +18,7 @@ namespace H5PXAPIKATCHU;
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
 if ( ! defined( 'H5PXAPIKATCHU_VERSION' ) ) {
-	define( 'H5PXAPIKATCHU_VERSION', '0.4.2' );
+	define( 'H5PXAPIKATCHU_VERSION', '0.4.3' );
 }
 
 // settings.php contains all functions for the settings
@@ -238,6 +238,7 @@ function insert_data() {
 	$xapi     = $_REQUEST['xapi'];
 
 	// If fuction h5pxapikatchu_custom_insert_data exists, delegate
+	// Added in version 0.4.3
 	if (function_exists('h5pxapikatchu_custom_insert_data')) {
 		if ( h5pxapikatchu_custom_insert_data( $xapi ) ) {
 			wp_die();


### PR DESCRIPTION
H5PxAPIkatchu is a Wonderful plugin, but I think it will be even better if it gives the opportunity to record H5P xAPI events elsewhere through a custom function. Only 3 lines of code are required for that. Personally, I record these events in a MongoDB data base using something like:

// Custom h5pxapikatchu data insertion
function h5pxapikatchu_custom_insert_data( $actor, $verb, $object, $result, $xapi ) {
  $response = false;

  try {
    $manager = new MongoDB\Driver\Manager( 'mongodb://......' );
    $bulk = new MongoDB\Driver\BulkWrite;
    $doc = [
      'actor' => $actor,
      'verb' => $verb,
      'object' => $object,
      'result' => $result,
      'xapi' => $xapi,
    ];
    $bulk->insert( $doc );
    $result = $manager->executeBulkWrite( 'db.h5p', $bulk );
    $response = true;
  } catch (Throwable $e) {
    //echo "Captured Throwable: " . $e->getMessage() . PHP_EOL;
    // Manage error here...
  }
  return $response;
}

... and in case the external database is not available, the function returns false and H5PxAPIkatchu records the event in the internal MySQL database as it uses to do, which is just fine as an emergency backup.